### PR TITLE
Fixes that the monitor cannot be disabled

### DIFF
--- a/pyzm/helpers/Monitor.py
+++ b/pyzm/helpers/Monitor.py
@@ -146,7 +146,7 @@ class Monitor(Base):
             payload['Monitor[Function]'] = options.get('function')
         if options.get('name'):
             payload['Monitor[Name]'] = options.get('name')
-        if options.get('enabled'):
+        if options.get('enabled') != None:
             enabled = '1' if options.get('enabled') else '0'
             payload['Monitor[Enabled]'] = enabled
 


### PR DESCRIPTION
If 'False' is passed for the 'enabled' key in the options dictionary, the value of the key is not included in the payload. 
The check for the existence of the key in the dictionary should be more explicit to check for None.