### PR TITLE
Added the missing 'Warning' function in SimpleLog

### DIFF
--- a/pyzm/helpers/Base.py
+++ b/pyzm/helpers/Base.py
@@ -28,6 +28,9 @@ class SimpleLog:
     def Info (self,message, caller=None):
         print ('[INFO] {}'.format( message))
 
+    def Warning (self,message, caller=None):
+        print ('[WARNING] {}'.format( message))
+
     def Error (self,message, caller=None):
         print ('[ERROR] {}'.format(message))
 


### PR DESCRIPTION
ZMEventNotification.py is using the Warning function of the logger, but if SimpleLog is used, the 'Warning' function was not present.