### PR TITLE
Add support for Event.delete()

### DIFF
--- a/pyzm/api.py
+++ b/pyzm/api.py
@@ -253,7 +253,13 @@ class ZMApi (Base):
             #print (url, params)
             #r = requests.get(url, params=params)
             r.raise_for_status()
-            return r.json()
+
+            # Empty response, e.g. to DELETE requests, can't be parsed to json
+            # even if the content-type says it is application/json
+            if r.headers.get('content-type').startswith("application/json") and r.text:
+                return r.json()
+            return r.text
+
         except requests.exceptions.HTTPError as err:
             self.logger.Debug(1, 'Got API access error: {}'.format(err))
             if err.response.status_code == 401 and reauth:

--- a/pyzm/helpers/Event.py
+++ b/pyzm/helpers/Event.py
@@ -82,6 +82,15 @@ class Event(Base):
         f =  self._download_file(url, str(self.id())+'-video'+'.mp4', dir, show_progress)
         self.logger.Info('File downloaded to {}'.format(f))
 
+    def delete(self):
+        """Deletes this event
+
+        Returns:
+            json: API response
+        """
+        url = self.api.api_url+'/events/{}.json'.format(self.id())
+        return self.api._make_request(url=url, type='delete')
+
     def monitor_id(self):
         """returns monitor ID of event object.
 


### PR DESCRIPTION
Fix for #18 

It needed a little change in `api._make_request()` because the `DELETE` doesn't return *json* which trips up the `r.json()` function.