### PR TITLE
Fix face_model option name

### DIFF
--- a/pyzm/ml/face_dlib.py
+++ b/pyzm/ml/face_dlib.py
@@ -46,7 +46,7 @@ class FaceDlib(Face):
 
         upsample_times = self.options.get('upsample_times',1)
         num_jitters= self.options.get('num_jitters',0)
-        model=self.options.get('model','hog')
+        model=self.options.get('face_model','hog')
 
         g.logger.Debug(
             1,'Initializing face recognition with model:{} upsample:{}, jitters:{}'


### PR DESCRIPTION
The library is pulling an invalid option so the debug log always shows 'hog' as the model.  This occurs even when `face_model` is set to `cnn`.  As in `Initializing face recognition with model:hog upsample:1, jitters:0`


This issue only affects the debug statement and not the running of the code.

