### PR TITLE
Update virel.ai to parse response data.

### DIFF
--- a/pyzm/ml/virelai.py
+++ b/pyzm/ml/virelai.py
@@ -49,7 +49,7 @@ class VirelAI(Base):
             raise
 
         
-        g.logger.Debug(1, 'remote detection inferencing took: {} s'.format(time.perf_counter - start))
+        g.logger.Debug(1, 'remote detection inferencing took: {} s'.format(time.perf_counter() - start))
         # Parse the returned labels
         bboxes = []
         labels = []

--- a/pyzm/ml/virelai.py
+++ b/pyzm/ml/virelai.py
@@ -58,10 +58,10 @@ class VirelAI(Base):
         try:
             response = r.json()
         except json.JSONDecodeError as e:
-            logger.error(f"Error decoding virelai api response: {e}")
+            g.logger.Error(f"Error decoding virelai api response: {e}")
         else:
 
-            logger.debug(
+            g.logger.Debug(2, 
                 f"{model_name} detection response -> {response}"
             )
             # Parse the returned labels
@@ -93,6 +93,8 @@ class VirelAI(Base):
                 bboxes.append(bbox)
                 labels.append(label)
                 confs.append(conf)
+                g.logger.Debug(3, 'bbox={} / label={} / conf={}'.format(bbox, label, conf))
+                
         return bboxes, labels, confs, [model_name]*len(labels)
 
     def get_detect_image(self, image=None):

--- a/pyzm/ml/virelai.py
+++ b/pyzm/ml/virelai.py
@@ -14,11 +14,8 @@ import pyzm.helpers.globals as g
 class VirelAI(Base):
     def __init__(self, options={}):
         self.options = options
-        self.min_confidence = self.options.get('object_min_confidence', 0.7)
-        if self.min_confidence < 1: # Rekognition wants the confidence as 0% ~ 100%, not 0.00 ~ 1.00
-            self.min_confidence *= 100
-
-        g.logger.Debug (2, 'VirelAI initialised (min confidence: {}%'.format(self.min_confidence))
+        self.min_confidence = float(self.options.get('object_min_confidence', 0.5))
+        g.logger.Debug (2, 'VirelAI initialised (min confidence: {}'.format(self.min_confidence))
 
     def detect(self, image=None):
         height, width = image.shape[:2]
@@ -76,8 +73,9 @@ class VirelAI(Base):
                 #   ]
                 # }
                 conf = float(item["Confidence"]) / 100
-                #if conf < _conf:
-                #    continue
+                if conf < float(self.min_confidence):
+                    g.logger.Warning(f"{model_name}: confidence={conf} - min conf threshold={self.min_confidence}")
+                    continue
                 label = item["Name"].casefold()
                 # Virel.ai does not return bounding box coords yet.
                 # box = item["BoundingBox"]

--- a/pyzm/ml/virelai.py
+++ b/pyzm/ml/virelai.py
@@ -4,6 +4,7 @@
 import io
 import sys
 import base64
+import time
 
 import cv2
 
@@ -36,7 +37,7 @@ class VirelAI(Base):
         object_url = api_url+'/api/detect/payload'
         g.logger.Debug(2, 'Invoking virelai api with url:{} and headers={} '.format(object_url, auth_header))
 
-        start = datetime.datetime.now()
+        start = time.perf_counter()
         try:
             headers = {'Content-type': 'application/json; charset=utf-8'}
             r = requests.post(url=object_url, headers=headers, json=files)
@@ -47,36 +48,52 @@ class VirelAI(Base):
             g.logger.Debug(2, traceback.format_exc())
             raise
 
-        diff_time = (datetime.datetime.now() - start)
-        g.logger.Debug(1, 'remote detection inferencing took: {}'.format(diff_time))
-        response = r.json()
         
+        g.logger.Debug(1, 'remote detection inferencing took: {} s'.format(time.perf_counter - start))
         # Parse the returned labels
         bboxes = []
         labels = []
         confs = []  # Confidences
+        model_name = 'VirelAI:'
+        try:
+            response = r.json()
+        except json.JSONDecodeError as e:
+            logger.error(f"Error decoding virelai api response: {e}")
+        else:
 
-        for item in response['Labels']:
-            if 'Instances' not in item:
-                continue
-            for instance in item['Instances']:
-                if not 'BoundingBox' in instance or not 'Confidence' in instance:
-                    continue
-                label = item['Name'].lower()
-                conf = instance['Confidence']/100
-                bbox = (
-                    round(width * instance['BoundingBox']['Left']),
-                    round(height * instance['BoundingBox']['Top']),
-                    round(width * (instance['BoundingBox']['Left'] + instance['BoundingBox']['Width'])),
-                    round(height * (instance['BoundingBox']['Top'] + instance['BoundingBox']['Height']))
-                )
-                g.logger.Debug(3, 'bbox={} / label={} / conf={}'.format(bbox, label, conf))
+            logger.debug(
+                f"{model_name} detection response -> {response}"
+            )
+            # Parse the returned labels
+            model_name = f"{model_name}:{repr(response['LabelModelVersion'])}"
+            for item in response["Labels"]:
+                # {
+                # "LabelModelVersion": "detect-1",
+                # "Img": "",
+                # "Labels": [
+                #   {"Confidence": "78.06", "Name": "person"},
+                #   {"Confidence": "75.35", "Name": "person"}
+                #   ]
+                # }
+                conf = float(item["Confidence"]) / 100
+                #if conf < _conf:
+                #    continue
+                label = item["Name"].casefold()
+                # Virel.ai does not return bounding box coords yet.
+                # box = item["BoundingBox"]
 
+                # bbox = (
+                #     round(w * box["Left"]),
+                #     round(h * box["Top"]),
+                #     round(w * (box["Left"] + box["Width"])),
+                #     round(h * (box["Top"] + box["Height"])),
+                # )
+                # return false bbox data for now
+                bbox = (0, 0, 0, 0)
                 bboxes.append(bbox)
                 labels.append(label)
                 confs.append(conf)
-
-        return bboxes, labels, confs, ['VirelAI']*len(labels)
+        return bboxes, labels, confs, [model_name]*len(labels)
 
     def get_detect_image(self, image=None):
         is_success, _buff = cv2.imencode('.jpg', image)


### PR DESCRIPTION
Virel.ai does not reply with bounding box info. This will cause issues, for now the bbox data is set to 0,0,0,0. Hopefully this allows ZMES to complete the detection and add it as a hit. Image will not be annotated correctly if it does. This code parses the current response from virel.ai to grab Label and confidence, type cast confidence into a float and populate bbox data with 0,0,0,0.

This may not work for ZMES post processing, I do not have ZMES to test with but, it will return what data it can.

Added `model_name` to grab the model str that virel.ai returns. Made use of `time.perf_counter()` for performance timing.

Confidence threshold needs to be added for confidence comparison.